### PR TITLE
Use dot arguments in cartogram call

### DIFF
--- a/R/tm_layers_cartogram.R
+++ b/R/tm_layers_cartogram.R
@@ -105,8 +105,8 @@ opt_tm_cartogram = function(type = "cont",
 							itermax = 15,
 							...) {
 	list(cartogram = list(mapping.args = list(),
-						  trans.args = list(type = type, itermax = itermax)),
-		 polygons = do.call(tmap::opt_tm_polygons, list(...)))
+						  trans.args = list(type = type, itermax = itermax, ...)),
+		 polygons = do.call(tmap::opt_tm_polygons, list()))
 }
 
 #' @rdname tm_cartogram
@@ -119,8 +119,8 @@ opt_tm_cartogram_ncont = function(type = "ncont",
 								  ...) {
 
 	list(cartogram = list(mapping.args = list(),
-						  trans.args = list(type = type, expansion = expansion, inplace = inplace)),
-		 polygons = do.call(tmap::opt_tm_polygons, list(...)))
+						  trans.args = list(type = type, expansion = expansion, inplace = inplace, ...)),
+		 polygons = do.call(tmap::opt_tm_polygons, list()))
 }
 
 
@@ -132,6 +132,6 @@ opt_tm_cartogram_dorling = function(type = "dorling",
 									itermax = 1000,
 									...) {
 	list(cartogram = list(mapping.args = list(),
-						  trans.args = list(type = type, share = share, itermax = itermax)),
-		 polygons = do.call(tmap::opt_tm_polygons, list(...)))
+						  trans.args = list(type = type, share = share, itermax = itermax, ...)),
+		 polygons = do.call(tmap::opt_tm_polygons, list()))
 }

--- a/R/tmapTransCartogram.R
+++ b/R/tmapTransCartogram.R
@@ -24,14 +24,16 @@ tmapTransCartogram = function(shpTM, size, ord__, plot.order, args, scale) {
 
 
 	if (args$type == "cont") {
-		xargs = list(itermax = args$itermax)
+		xargs = args[names(args) != "type"]
 
 		#shp = suppressMessages(suppressWarnings({cartogram::cartogram_cont(x, weight = "weight", itermax = args$itermax)}))
 	} else if (args$type == "ncont") {
-		xargs = list(k = args$expansion, inplace = args$inplace)
+		xargs = args[names(args) != "type"]
+		names(xargs)[names(xargs) == "expansion"] <- "k"
 		#shp = suppressMessages(suppressWarnings({cartogram::cartogram_ncont(x, weight = "weight", k = args$expansion, inplace = args$inplace)}))
 	} else if (args$type == "dorling") {
-		xargs = list(k = args$share, itermax = args$itermax)
+		xargs = args[names(args) != "type"]
+		names(xargs)[names(xargs) == "share"] <- "k"
 		#shp = suppressMessages(suppressWarnings({cartogram::cartogram_dorling(x, weight = "weight", k = args$share, itermax = args$itermax)}))
 	} else {
 		stop("unknown cartogram type", call. = FALSE)


### PR DESCRIPTION
Hi @mtennekes ,

I did some tests with the latest version of cartogram and found that dot-arguments don't get transferred to cartogram_cont.

This PR should fix that (the example show, that maxSizeError ist adjusted in the second example) . 

```
> tm_shape(Africa, crs = "+proj=robin") +
+   tm_cartogram(size = "pop_est", options = opt_tm_cartogram(itermax = 50, maxSizeError = 0.8))
Cartogram in progress...
 [Iter.:50/50] ======================================== 100%
> tm_shape(Africa, crs = "+proj=robin") +
+   tm_cartogram(size = "pop_est", options = opt_tm_cartogram(itermax = 50, maxSizeError = 1.8))
Cartogram in progress...
 [Iter.:4/50] ===.....................................   8%
```